### PR TITLE
Minor fixes for abstracts

### DIFF
--- a/_posts/2009-04-15-armagan09a.md
+++ b/_posts/2009-04-15-armagan09a.md
@@ -8,7 +8,7 @@ abstract: Here we obtain approximate Bayes inferences through variational method
   the variational distributions for the regression coefficients. By choosing specific
   values of hyper-parameters (tuning parameters) present in the model, we can mimic
   the model selection performance of best subset selection in sparse underlying settings.
-  The fundamental difference between MAP, \emphmaximum a posteriori, estimation and
+  The fundamental difference between MAP, maximum a posteriori, estimation and
   the proposed method is that, here we can obtain approximate inferences besides a
   point estimator. We also empirically analyze the frequentist properties of the estimator
   obtained. Results suggest that the proposed method yields an estimator that performs

--- a/_posts/2009-04-15-chang09a.md
+++ b/_posts/2009-04-15-chang09a.md
@@ -4,9 +4,9 @@ abstract: We develop the relational topic model (RTM), a model of documents and 
   links between them. For each pair of documents, the RTM models their link as a binary
   random variable that is conditioned on their contents. The model can be used to
   summarize a network of documents, predict links between them, and predict words
-  within them. We derive efﬁcient inference and learning algorithms based on variational
+  within them. We derive efficient inference and learning algorithms based on variational
   methods and evaluate the predictive performance of the RTM for large networks of
-  scientiﬁc abstracts and web documents.
+  scientific abstracts and web documents.
 pdf: http://proceedings.mlr.press/v5/chang09a/chang09a.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research

--- a/_posts/2009-04-15-crammer09a.md
+++ b/_posts/2009-04-15-crammer09a.md
@@ -1,7 +1,7 @@
 ---
 title: Gaussian Margin Machines
 abstract: We introduce Gaussian Margin Machines   (GMMs), which maintain a Gaussian
-  distribu-   tion over weight vectors for binary classiﬁcation.   The learning algorithm
+  distribution over weight vectors for binary classification. The learning algorithm
   for these machines   seeks the least informative distribution that will   classify
   the training data correctly with high   probability. One formulation can be expressed   as
   a convex constrained optimization problem   whose solution can be represented linearly   in
@@ -9,13 +9,13 @@ abstract: We introduce Gaussian Margin Machines   (GMMs), which maintain a Gauss
   algorithm has a natural PAC-Bayesian   generalization bound. A preliminary evaluation   on
   handwriting recognition data shows that our   algorithm improves over SVMs for the
   same   task.   methods, we maintain a distribution over alternative weight   vectors,
-  rather than committing to a single speciﬁc one.   However, these distributions are
+  rather than committing to a single specific one. However, these distributions are
   not derived by Bayes? rule.   Instead, they represent our knowledge of the weights
-  given   constraints imposed by the training examples. Speciﬁcally,   we use a Gaussian
+  given constraints imposed by the training examples. Specifically, we use a Gaussian
   distribution over weight vectors with   mean and covariance parameters that are
-  learned from the   training data. The learning algorithm seeks for a distribu-   tion
+  learned from the training data. The learning algorithm seeks for a distribution
   with a small Kullback-Leibler (KL) divergence from a   ﬁxed isotropic distribution,
-  such that each training exam-   ple is correctly classiﬁed by a strict majority
+  such that each training example is correctly classified by a strict majority
   of the weight   vectors. Conceptually, this is a large-margin probabilistic   principle,
   instead of the geometric large margin principle   in SVMs.   The learning problem
   for GMMs can be expressed as a   convex constrained optimization, and its optimal

--- a/_posts/2009-04-15-erhan09a.md
+++ b/_posts/2009-04-15-erhan09a.md
@@ -3,7 +3,7 @@ title: The Difficulty of Training Deep Architectures and the Effect of Unsupervi
   Pre-Training
 abstract: Whereas theoretical work suggests that deep architectures might be more
   efficient at representing highly-varying functions, training deep architectures  was
-  unsuccessful until the recent advent of algorithms based on unsupervised pretraining.
+  unsuccessful until the recent advent of algorithms based on unsupervised pre-training.
   Even though these new algorithms have enabled training deep models, many questions
   remain as to the nature of this difficult learning problem. Answering these questions
   is important if learning in deep architectures is to be further improved. We attempt

--- a/_posts/2009-04-15-givoni09a.md
+++ b/_posts/2009-04-15-givoni09a.md
@@ -3,7 +3,7 @@ title: Semi-Supervised Affinity Propagation with Instance-Level Constraints
 abstract: 'Recently, affinity propagation (AP) was introduced  as an unsupervised
   learning algorithm for  exemplar based clustering. Here we extend the  AP model
   to account for semi-supervised clustering.  AP, which is formulated as inference
-  in  a factor-graph, can be naturally extended to account  for ?instance-level? constraints:
+  in  a factor-graph, can be naturally extended to account  for `instance-level’ constraints:
   pairs of  data points that cannot belong to the same cluster  (cannot-link), or
   must belong to the same cluster  (must-link). We present a semi-supervised AP algorithm  (SSAP)
   that can use instance-level constraints  to guide the clustering. We demonstrate  the

--- a/_posts/2009-04-15-guan09a.md
+++ b/_posts/2009-04-15-guan09a.md
@@ -3,10 +3,10 @@ title: Sparse Probabilistic Principal Component Analysis
 abstract: "Principal component analysis (PCA) is a  popular dimensionality reduction
   algorithm.  However, it is not easy to interpret which of  the original features
   are important based on  the principal components. Recent methods
-  improve interpretability by sparsifying PCA  through adding an L1
+  improve interpretability by sparsifying PCA through adding an $L_1$
   regularizer. In this paper,  we introduce a probabilistic formulation  for sparse PCA. By presenting sparse PCA  as a probabilistic
   Bayesian formulation, we  gain the benefit of automatic model selection.  We examine
-  three different priors for achieving  sparsification: (1) a two-level hierarchical prior equivalent to a Laplacian distribution  and consequently to an L1 regularization, (2)  an inverse-Gaussian prior, and (3) a Jeffrey’s  prior. We learn these models by applying  variational inference. Our experiments verify  that indeed our sparse probabilistic model  results in a sparse PCA solution."
+  three different priors for achieving  sparsification: (1) a two-level hierarchical prior equivalent to a Laplacian distribution and consequently to an $L_1$ regularization, (2) an inverse-Gaussian prior, and (3) a Jeffrey’s prior. We learn these models by applying variational inference. Our experiments verify that indeed our sparse probabilistic model  results in a sparse PCA solution."
 pdf: http://proceedings.mlr.press/v5/guan09a/guan09a.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research

--- a/_posts/2009-04-15-ihler09a.md
+++ b/_posts/2009-04-15-ihler09a.md
@@ -10,7 +10,7 @@ abstract: The popularity of particle filtering for inference in Markov chain mod
   related to previously proposed methods.  We prove that this algorithm is consistent,
   approaching the true BP messages as the number of samples grows large. We then use
   concentration bounds to analyze the finite-sample behavior and give a convergence
-  rate for the algorithm on tree–structured graphs.  Our convergence rate is O(1/\sqrtn)
+  rate for the algorithm on tree–structured graphs. Our convergence rate is $O(1/\sqrt{n})$
   where n is the number of samples, independent of the domain size of the variables.
 pdf: http://proceedings.mlr.press/v5/ihler09a/ihler09a.pdf
 layout: inproceedings

--- a/_posts/2009-04-15-kanade09a.md
+++ b/_posts/2009-04-15-kanade09a.md
@@ -5,7 +5,7 @@ abstract: We consider algorithms for selecting actions in order to maximize rewa
   chosen by an adversary, where the set of actions available on any given round is
   selected stochastically. We present the first polynomial-time no-regret algorithms
   for this setting. In the full-observation (experts) version of the problem, we present
-  an exponential-weights algorithm that  achieves regret O(\sqrtT log n), which is
+  an exponential-weights algorithm that achieves regret $\mathcal{O}(\sqrt{T \log n})$, which is
   the best possible. For the bandit setting (where the algorithm only observes the
   reward of the action selected), we present a no-regret algorithm based on follow-the-perturbed-leader.
   This algorithm runs in polynomial time, unlike the EXP4 algorithm which can also

--- a/_posts/2009-04-15-larochelle09a.md
+++ b/_posts/2009-04-15-larochelle09a.md
@@ -3,10 +3,10 @@ title: Deep Learning using Robust Interdependent Codes
 abstract: We investigate a simple yet effective method to introduce inhibitory and  excitatory
   interactions between units in the layers of a deep neural  network classifier. The
   method is based on the greedy layer-wise procedure  of deep learning algorithms
-  and extends the denoising autoencoder of  Vincent et al. \citeVincentPLarochelleH2008-small
+  and extends the denoising autoencoder of (Vincent et al., 2008)
   by adding asymmetric  lateral connections between its hidden coding units, in a
   manner that is much simpler and  computationally more efficient than previously
-  proposed approaches.We  present experiments on two character recognition problems
+  proposed approaches. We present experiments on two character recognition problems
   which show for  the first time that lateral connections can significantly improve
   the  classification performance of deep networks.
 pdf: http://proceedings.mlr.press/v5/larochelle09a/larochelle09a.pdf

--- a/_posts/2009-04-15-liu09a.md
+++ b/_posts/2009-04-15-liu09a.md
@@ -1,6 +1,6 @@
 ---
 title: Estimation Consistency of the Group Lasso and its Applications
-abstract: We extend the  \ell_2-consistency result of (Meinshausen and Yu 2008) from
+abstract: We extend the $\ell_2$-consistency result of (Meinshausen and Yu 2008) from
   the Lasso to  the group Lasso. Our main theorem shows that the group Lasso  achieves
   estimation consistency under a mild condition and an asymptotic upper bound on the
   number of selected variables can be obtained.  As a result, we can apply the nonnegative

--- a/_posts/2009-04-15-mandhani09a.md
+++ b/_posts/2009-04-15-mandhani09a.md
@@ -1,7 +1,7 @@
 ---
 title: Tractable Search for Learning Exponential Models of Rankings
 abstract: We consider the problem of learning the Generalized Mallows (GM) model  of
-  \citefv86, which represents a probability distribution over all  possible permutations
+  [Fligner and Verducci, 1986], which represents a probability distribution over all  possible permutations
   (aka rankings) of a given set of objects. The  training data consists of a set of
   permutations. This problem  generalizes the well known rank aggregation problem.
   Maximum  Likelihood estimation of the GM model is NP-hard. An exact but  inefficient

--- a/_posts/2009-04-15-ralaivola09a.md
+++ b/_posts/2009-04-15-ralaivola09a.md
@@ -1,18 +1,18 @@
 ---
 title: Chromatic PAC-Bayes Bounds for Non-IID Data
-abstract: Pac-Bayes bounds are among the most accurate    generalization bounds for
+abstract: PAC-Bayes bounds are among the most accurate generalization bounds for
   classifiers learned with IID data, and it    is particularly so for margin classifiers.  However,
   there are many    practical cases where the training data show some dependencies
   and    where the traditional IID assumption does not apply. Stating    generalization
   bounds for such frameworks is therefore of the utmost    interest, both from theoretical
-  and practical standpoints.  In this    work, we propose the first – to the best
-  of our knowledge –    \pac-Bayes generalization bounds for classifiers trained on
+  and practical standpoints. In this work, we propose the first – to the best
+  of our knowledge –  PAC-Bayes generalization bounds for classifiers trained on
   data    exhibiting dependencies. The approach undertaken to establish our    results
   is based on the decomposition of a so-called dependency    graph that encodes the
   dependencies within the data, in sets of    independent data, through the tool of
   graph fractional covers.  Our    bounds are very general, since being able to find
   an upper bound on    the (fractional) chromatic number of the dependency graph is    sufficient
-  to get new \pac-Bayes bounds for specific settings.  We    show how our results
+  to get new PAC-Bayes bounds for specific settings. We show how our results
   can be used to derive bounds for bipartite    ranking and windowed prediction on
   sequential data.
 pdf: http://proceedings.mlr.press/v5/ralaivola09a/ralaivola09a.pdf

--- a/_posts/2009-04-15-ratliff09a.md
+++ b/_posts/2009-04-15-ratliff09a.md
@@ -3,16 +3,16 @@ title: Inverse Optimal Heuristic Control for Imitation Learning
 abstract: 'Imitation learning is an increasingly important tool for both developing  automatic
   decision making systems as well as for learning to predict  decision-making and
   behavior by observation. Two basic approaches are common:  the first, which we here
-  term \emphbehavioral cloning   (BC)\citeBehavioralCloning,ALVINN,DAVE, treats the
+  term behavioral cloning (BC)\citeBehavioralCloning,ALVINN,DAVE, treats the
   imitation learning problem  as a straightforward one of supervised learning (e.g.
   classification) where the  goal is to map observations to controls.  Secondly, the
-  notion of\emphinverse  optimal control (IOC) \citeBoydIOC,ng00irl,Abbeel04c,mmp06
+  notion of inverse optimal control (IOC) \citeBoydIOC,ng00irl,Abbeel04c,mmp06
   for  modeling   such decision making behavior has gained prominence as it allows
   for learned   decision-making that reasons sequentially and over a long horizon.  Unfortunately,
   such inverse optimal control methods rely upon the ability to   efficiently solve
   a planning problem and suffer from the usual “curse of  dimensionality” when the
   state space gets large. This paper presents a novel  approach to imitation learning
-  that we call \emphInverse Optimal Heuristic  Control (IOHC) which capitalizes on
+  that we call Inverse Optimal Heuristic Control (IOHC) which capitalizes on
   the strengths of both paradigms by  allowing long-horizon, planning style reasoning
   in a low dimensional space,  while enabling a high dimensional additional set of
   features to guide overall  action selection.  We frame this combined problem as

--- a/_posts/2009-04-15-rooij09a.md
+++ b/_posts/2009-04-15-rooij09a.md
@@ -1,16 +1,16 @@
 ---
 title: Learning the Switching Rate by Discretising Bernoulli Sources Online
 abstract: 'The expert tracking algorithm Fixed-Share  depends on a parameter alpha,
-  called the switching  rate. If the final number of outcomes  T is known in advance,
-  then the switching  rate can be learned with regret 1/2 log T +  O(1) bits. The
+  called the switching rate. If the final number of outcomes $T$ is known in advance,
+  then the switching rate can be learned with regret $\frac{1}{2} \log T + O(1)$ bits. The
   current fastest method that  achieves this, Learn-alpha, is based on optimal  discretisation
-  of the Bernoulli distributions  into O(√T) bins and runs in O(T√T) time;  however
+  of the Bernoulli distributions into $O(\sqrt{T})$ bins and runs in $(T\sqrt{T})$ time; however
   the exact locations of these points  have to be determined algorithmically.    This
   paper introduces a new discretisation  scheme with the same regret bound for  known
-  T, that specifies the number and positions  of the discretisation points explicitly.  The
-  scheme is especially useful when T is not  known in advance: a new fully on-line
-  algorithm,  Refine-Online, is presented, which  runs in O(T√T log T) time and achieves
-  a  regret of 1/2 log 3 log T + O(log log T) bits.'
+  $T$, that specifies the number and positions of the discretisation points explicitly. The
+  scheme is especially useful when $T$ is not known in advance: a new fully online
+  algorithm, Refine-Online, is presented, which  runs in $O(T \sqrt{T} \log T)$ time and achieves
+  a  regret of $\frac{1}{2} \log 3 \log T + O(\log \log T)$ bits.'
 pdf: http://proceedings.mlr.press/v5/rooij09a/rooij09a.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research

--- a/_posts/2009-04-15-shervashidze09a.md
+++ b/_posts/2009-04-15-shervashidze09a.md
@@ -2,7 +2,7 @@
 title: Efficient graphlet kernels for large graph comparison
 abstract: State-of-the-art  graph kernels do not scale to large graphs with hundreds
   of nodes and thousands of edges. In this article we propose to compare graphs by
-  counting  \it graphlets, \ie subgraphs with k nodes where k ∈{ 3, 4, 5 }. Exhaustive
+  counting graphlets, i.e., subgraphs with $k$ nodes where $k \in \{ 3, 4, 5 \}$. Exhaustive
   enumeration of all graphlets being prohibitively expensive, we introduce two theoretically
   grounded speedup schemes, one based on sampling and the second one specifically
   designed for bounded degree graphs. In our experimental evaluation, our novel kernels

--- a/_posts/2009-04-15-stepleton09a.md
+++ b/_posts/2009-04-15-stepleton09a.md
@@ -1,7 +1,7 @@
 ---
 title: The Block Diagonal Infinite Hidden Markov Model
 abstract: The Infinite Hidden Markov Model (IHMM) extends hidden Markov models to
-  have a countably infinite number of hidden states \citeihmm,hdp. We present a generalization
+  have a countably infinite number of hidden states (Beal et al., 2002; Teh et al., 2006). We present a generalization
   of this framework that introduces block-diagonal structure in the transitions between
   the hidden states. These blocks correspond to “sub-behaviors” exhibited by data
   sequences. In identifying such structure, the model classifies, or partitions, sequence

--- a/_posts/2009-04-15-wood09a.md
+++ b/_posts/2009-04-15-wood09a.md
@@ -6,7 +6,7 @@ abstract: In this paper we present a doubly hierarchical Pitman-Yor process lang
   process language models, one each for some number of domains. The novel top layer
   of hierarchy consists of a mechanism to couple together multiple language models
   such that they share statistical strength. Intuitively this sharing results in the
-  ?adaptation? of a latent shared language model to each domain. We introduce a general
+  “adaptation” of a latent shared language model to each domain. We introduce a general
   formalism capable of describing the overall model which we call the graphical Pitman-Yor
   process and explain how to perform Bayesian inference in it. We present encouraging
   language model domain adaptation results that both illustrate the potential benefits

--- a/_posts/2009-04-15-xi09a.md
+++ b/_posts/2009-04-15-xi09a.md
@@ -1,16 +1,16 @@
 ---
 title: Speed and Sparsity of Regularized Boosting
-abstract: Boosting algorithms with l1 regularization are of interest because l1 regularization
+abstract: Boosting algorithms with $l_1$ regularization are of interest because $l_1$ regularization
   leads to sparser composite classifiers. Moreover, Rosset et al. have shown that
-  for separable data, standard lp regularized loss minimization results in a margin
-  maximizing classifier in the limit as regularization is relaxed. For the case p=1,
+  for separable data, standard $l_p$ regularized loss minimization results in a margin
+  maximizing classifier in the limit as regularization is relaxed. For the case $p=1$,
   we extend these results by obtaining explicit convergence bounds on the regularization
   required to yield a margin within prescribed accuracy of the maximum achievable
-  margin. We derive similar rates of convergence for the epsilon AdaBoost algorithm,
-  in the process providing a new proof that epsilon AdaBoost is margin maximizing
-  as epsilon converges to 0. Because both of these known algorithms are computationally
-  expensive, we introduce a new hybrid algorithm, AdaBoost+L1, that combines the virtues
-  of AdaBoost with the sparsity of l1 regularization in a computationally efficient
+  margin. We derive similar rates of convergence for the $\epsilon$-AdaBoost algorithm,
+  in the process providing a new proof that $\epsilon$-AdaBoost is margin maximizing
+  as $\epsilon$ converges to $0$. Because both of these known algorithms are computationally
+  expensive, we introduce a new hybrid algorithm, AdaBoost+$L_1$, that combines the virtues
+  of AdaBoost with the sparsity of $l_1$ regularization in a computationally efficient
   fashion. We prove that the algorithm is margin maximizing and empirically examine
   its performance on five datasets.
 pdf: http://proceedings.mlr.press/v5/xi09a/xi09a.pdf

--- a/_posts/2009-04-15-yu09a.md
+++ b/_posts/2009-04-15-yu09a.md
@@ -1,12 +1,12 @@
 ---
 title: Active Sensing
-abstract: Labels are often expensive to get, and this motivates \emphactive learning
+abstract: Labels are often expensive to get, and this motivates active learning
   which chooses the most informative samples for label  acquisition. In this paper
-  we study \emphactive sensing in a  multi-view setting, motivated from many problems
-  where grouped  features are also expensive to obtain and need to be acquired (or  \emphsensed)
+  we study active sensing in a multi-view setting, motivated from many problems
+  where grouped features are also expensive to obtain and need to be acquired (or sensed)
   actively (e.g., in cancer diagnosis each patient might  go through many tests such
   as CT, Ultrasound and MRI to get valuable  features). The strength of this model
-  is that one actively sensed  (sample, view) pair would improve the \emphjoint multi-view  classification
+  is that one actively sensed (sample, view) pair would improve the joint multi-view  classification
   on all the samples. For this purpose we extend the  Bayesian co-training framework
   such that it can handle missing views  in a principled way, and introduce two criteria
   for view acquisition.  Experiments on one toy data and two real-world medical problems


### PR DESCRIPTION
This PR includes mainly the following minor fixes for the abstracts:

- Fix typos by following its manuscript
- Use math format
- Replace `\cite` with plain text


I realised that the abstract of [Inverse Optimal Heuristic Control for Imitation Learning](http://proceedings.mlr.press/v5/ratliff09a.html)  is not consistent with the abstract in the pdf file. So I updated its abstract as little as possible, but I'd happy to replace it if it is okay.